### PR TITLE
Fix for override of Links in Fastlonn, Fasttillegg and Variabellonn -…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,4 @@ ModelManifest.xml
 .idea
 .DS_Store
 *.orig
+*.ncrunchsolution

--- a/FINT.Model.Resource.Administrasjon.Tests/GenericLonnresourceUsage.cs
+++ b/FINT.Model.Resource.Administrasjon.Tests/GenericLonnresourceUsage.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FINT.Model.Administrasjon.Kompleksedatatyper;
+using FINT.Model.Administrasjon.Personal;
+using FINT.Model.Felles.Kompleksedatatyper;
+using Xunit;
+
+namespace FINT.Model.Resource.Administrasjon.Tests
+{
+    public class GenericLonnresourceUsage
+    {
+        [Fact]
+        public void FastlonnResource_should_be_LonnResource()
+        {
+            var kontostreng = new KontostrengResource();
+            kontostreng.AddAnsvar(Link.with("/administrasjon/kodeverk/ansvar/systemid/2"));
+            kontostreng.AddArt(Link.with("/administrasjon/kodeverk/art/systemid/1"));
+            kontostreng.AddFunksjon(Link.with("/administrasjon/kodeverk/funksjon/systemid/3"));
+
+            var fastlonn = new FastlonnResource
+            {
+                SystemId = new Identifikator {Identifikatorverdi = "ABC123"},
+                Attestert = new DateTime(),
+                Anvist = new DateTime(),
+                Periode = new Periode {Start = new DateTime()},
+                Prosent = 10000,
+                Beskrivelse = "Test",
+                Kontostreng = kontostreng
+            };
+
+
+            fastlonn.AddLonnsart(Link.with("/administrasjon/kodeverk/lonnsart/systemid/4"));
+            fastlonn.AddArbeidsforhold(Link.with("/administrasjon/personal/arbeidsforhold/systemid/1234"));
+
+            var genericLonnResource = fastlonn as LonnResource;
+
+
+            Assert.Equal("1234", genericLonnResource.Links.IdOf<Arbeidsforhold>());
+            
+
+            
+        }
+    }
+
+
+    public static class Extensions
+    {
+        public static string IdFromLink(this Link link)
+        {
+            if (link == null || string.IsNullOrEmpty(link.href))
+                return string.Empty;
+
+            var val = link.href.Split('/').Last();
+            return val;
+
+
+        }
+
+
+        public static string IdOf<T>(this Dictionary<string, List<Link>> links)
+        {
+            if (links == null) return string.Empty;
+
+            List<Link> f = null;
+
+            var name =  typeof(T).Name();
+            if (links.TryGetValue(name, out f))
+            {
+                return f.FirstOrDefault()?.IdFromLink();
+            }
+
+            return string.Empty;
+        }
+
+        
+        public static string Name(this Type type)
+        {
+            return type.Name.ToLower();
+
+        }
+    }
+
+
+}

--- a/FINT.Model.Resource.Administrasjon/Personal/FastlonnResource.cs
+++ b/FINT.Model.Resource.Administrasjon/Personal/FastlonnResource.cs
@@ -19,11 +19,12 @@ namespace FINT.Model.Administrasjon.Personal
         
         public FastlonnResource()
         {
-            Links = new Dictionary<string, List<Link>>();
+            //this.Links
+            //Links = new Dictionary<string, List<Link>>();
         }
 
-        [JsonProperty(PropertyName = "_links")]
-        public new Dictionary<string, List<Link>> Links { get; private set; }
+        //[JsonProperty(PropertyName = "_links")]
+        //public new Dictionary<string, List<Link>> Links { get; private set; }
         
         private void AddLink(string key, Link link)
         {

--- a/FINT.Model.Resource.Administrasjon/Personal/FasttilleggResource.cs
+++ b/FINT.Model.Resource.Administrasjon/Personal/FasttilleggResource.cs
@@ -19,11 +19,11 @@ namespace FINT.Model.Administrasjon.Personal
         
         public FasttilleggResource()
         {
-            Links = new Dictionary<string, List<Link>>();
+            //Links = new Dictionary<string, List<Link>>();
         }
 
-        [JsonProperty(PropertyName = "_links")]
-        public new Dictionary<string, List<Link>> Links { get; private set; }
+        //[JsonProperty(PropertyName = "_links")]
+        //public new Dictionary<string, List<Link>> Links { get; private set; }
         
         private void AddLink(string key, Link link)
         {

--- a/FINT.Model.Resource.Administrasjon/Personal/LonnResource.cs
+++ b/FINT.Model.Resource.Administrasjon/Personal/LonnResource.cs
@@ -23,9 +23,9 @@ namespace FINT.Model.Administrasjon.Personal
 		public Periode Opptjent { get; set; }
 		public Periode Periode { get; set; }
 		public Identifikator SystemId { get; set; }
-		
-        
-        public LonnResource()
+
+
+	    protected LonnResource()
         {
             Links = new Dictionary<string, List<Link>>();
         }

--- a/FINT.Model.Resource.Administrasjon/Personal/VariabellonnResource.cs
+++ b/FINT.Model.Resource.Administrasjon/Personal/VariabellonnResource.cs
@@ -20,11 +20,11 @@ namespace FINT.Model.Administrasjon.Personal
         
         public VariabellonnResource()
         {
-            Links = new Dictionary<string, List<Link>>();
+            //Links = new Dictionary<string, List<Link>>();
         }
 
-        [JsonProperty(PropertyName = "_links")]
-        public new Dictionary<string, List<Link>> Links { get; private set; }
+        //[JsonProperty(PropertyName = "_links")]
+        //public new Dictionary<string, List<Link>> Links { get; private set; }
         
         private void AddLink(string key, Link link)
         {


### PR DESCRIPTION
I created a generic validation for LonnResource, but as the class FastlonnResource use the new keyword on Links, the Links property in the super class LonnResource is hidden. And its not possible to get to the super class Links property